### PR TITLE
Twitter Link in the 'Get Social' Section #31

### DIFF
--- a/layouts/partials/get-social.html
+++ b/layouts/partials/get-social.html
@@ -20,7 +20,7 @@
 				</div>
 			</div>
 			<div class="col-xs-20 match-height-item-by-row">
-				<p>Follow the official conference Twitter handle @JakartaOneConf for live event updates, speaker announcements, news and more!</p>
+				<p>Follow the official conference Twitter handle <a href="twitter.com/@JakartaOneConf">@JakartaOneConf</a> for live event updates, speaker announcements, news and more!</p>
 			</div>
 		</div>
 	</div>

--- a/less/custom.less
+++ b/less/custom.less
@@ -177,6 +177,15 @@ section#get-social {
     background-size: cover;
   }
 
+    a {
+        color: #feb322;
+        font-weight: 700;
+    }
+    
+    a:visited, a:hover, a:active {
+        color: #eda822;
+    }
+
   .fa.fa-twitter {
     width: 1.5em;
     border-radius: 100px;


### PR DESCRIPTION
Added link to twitter account on top of handle. Changed styling to be
bold gold to stand out.

Change-Id: I57979cf8298564f3f16d57afafdd0afdc47294e1
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>