### PR TITLE
JakartaOne Livestream schedule #33

### DIFF
--- a/data/agenda.yml
+++ b/data/agenda.yml
@@ -1,0 +1,92 @@
+types:
+    - name: Jakarta EE and MicroProfile Opening Sessions
+      class: opening 
+    - name: Demo
+      class: demo 
+    - name: Keynote
+      class: keynote 
+    - name: Cloud related topics
+      class: cloud
+    - name: Panel discussion/ How to contribute
+      class: panel 
+    - name: What's next for the specifications
+      class: whats-next
+
+items:
+    - name: Jakarta for DummEEs
+      presenter: Kevin Sutter
+      start: 7am EDT
+      type: opening
+    - name: Jakarta EE 8 - An Overview of Features
+      presenter: Josh Juneau
+      start: 8am EDT
+      type: opening
+    - name: Building Interoperable Microservices with Eclipse MicroProfile
+      presenter: Ivar Grimstad
+      start: 9am EDT
+      type: opening
+    - name: Live coding Jakarta EE + MicroProfile
+      presenter: Adam Bien
+      start: 10am EDT
+      type: demo
+    - name: It's Easy! Contributing to Jakarta EE Open source
+      presenter: Richard Monson-Haefel
+      start: 11am EDT
+      type: panel
+    - name: Opening Keynote
+      presenter: Mike Milinkovich, James Gosling
+      start: 12pm EDT
+      type: keynote
+    - name: Industry Keynote
+      presenter: Tomitribe, IBM, Oracle, Payara, Fujitsu
+      start: 12:20pm EDT
+      type: keynote
+    - name: Turbocharged Java with Quarkus
+      presenter: Marcus Biel
+      start: 1pm EDT
+      type: cloud
+    - name: Building Cloud-Native Microservices with Project Helidon
+      presenter: Dmitry Kornilov
+      start: 2pm EDT
+      type: cloud
+    - name: "Jakarta Concurrency: Present and Future"
+      presenter: Steve Millidge
+      start: 3pm EDT
+      type: whats-next
+    - name: "JSON support in Jakarta EE: Present and Future"
+      presenter: Dmitry Kornilov
+      start: 4pm EDT
+      type: whats-next
+    - name: Jakarta EE Steering Committee Panel
+      presenter: Members of the Jakarta EE Steering Committee
+      start: 5pm EDT
+      type: panel
+    - name: "Jakarta NoSQL: Meet the first Jakarta EE specification in the Cloud"
+      presenter: Otavio Santana
+      start: 6pm EDT
+      type: whats-next
+    - name: What's coming to Jakarta Security
+      presenter: Arjan Tijms
+      start: 7pm EDT
+      type: whats-next
+    - name: "Jakarta RESTful Web Services: Status Quo and Roadmap"
+      presenter: Markus Karg
+      start: 8pm EDT
+      type: whats-next
+    - name: "Jakarta Servlet: A new Twist on an Old Favourite"
+      presenter: Ed Burns
+      start: 9pm EDT
+      type: whats-next
+    - name: Jakarta Messaging 3.0, Redefining JMS
+      presenter: David Blevins
+      start: 10pm EDT
+      type: whats-next
+    - name: What's Coming to Jakarta Faces?
+      presenter: Arjan Tijms
+      start: 11pm EDT
+      type: whats-next
+    - name: Jakarta EE on Azure Magic Mystery Show
+      presenter: Reza Rahman
+      start: 12am EDT
+      type: cloud
+      

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -50,14 +50,42 @@
 			<div class="container" >
 			   <div class="col-xs-24" >
 			       <h2>Plan of the Day</h2>
-			       <p>Here is our high-level program plan for the day which spans across three different time zones;</p>
-			       <ul>
-		               <li>Keynotes</li>
-		               <li>Talks</li>
-		               <li>Demos</li>
-		               <li>Panels/Discussions</li>
-			       </ul>
-			       <p>Stay tuned for our upcoming updates on the keynotes!</p>
+			       <div class="row">
+			         <h3>Legend</h3>
+			         <ul type="none">
+				         {{ range .Site.Data.agenda.types }}
+				           <li><span class="{{ .class }}-icon icon">&nbsp;</span> {{ .name }}</li>
+				         {{ end  }}
+			         </ul>
+			       </div>
+			       <h3>Sessions</h3>
+			       <table class="table">
+                        <thead>
+                            <tr>
+                                <th>Session Name</th>
+                                <th>Presenter Name</th>
+                                <th>Start Time</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {{ range $.Site.Data.agenda.items }}
+                                <tr>
+                                    <td>
+                                        <span class="{{ .type }}-icon icon">
+                                            <span class="sr-only">
+                                                {{ range first 1 (where $.Site.Data.agenda.types "class" .type) }}
+                                                    {{ .name }}
+                                                {{ end }}
+                                            </span>
+                                        </span>
+                                        {{ .name }}
+                                    </td>
+                                    <td>{{ .presenter }}</td>
+                                    <td>{{ .start }}</td>
+                                </tr>
+                            {{ end }}
+                        </tbody>
+                   </table>
 			   </div>
 			</div>
 		</div>
@@ -67,6 +95,5 @@
 	{{ partial "program-committee.html" (dict "committee" $committee) }}
 	
 	{{ partial "get-social.html" }}
-	
 	
 {{ end }}

--- a/less/custom.less
+++ b/less/custom.less
@@ -127,24 +127,12 @@ footer#solstice-footer {
   min-width: calc(100% - 20px);
 }
 
-#cfp {
-  margin-bottom: -20px;
-}
-
-.cfp-backdrop {
-  background-image: url('images/papers-background.jpg');
-  background-size: cover;
-  background-position: bottom left;
-  background-repeat: no-repeat;
-  height: 100%;
-  position: relative;
-}
-
 .centered-container {
   width: 100%;
   position: absolute;
   top: 50%; left: 50%;
   transform: translate(-50%,-50%);
+  min-height: 100px;
 }
 
 section.alt {
@@ -152,7 +140,7 @@ section.alt {
     color: #fff;
   }
 
-  h2 {
+  h2, h3 {
     font-weight: 700;
     color: #fff;
   }
@@ -229,6 +217,35 @@ section#jakarta-ee p {
   #main-menu-wrapper {
     padding-top: 20px;
   }
+}
+
+span.icon::after {
+  content: '';
+  height: 15px;
+  width: 15px;
+  background-color: #bbb;
+  border-radius: 50%;
+  padding-top: 2px;
+  margin-right: 15px;
+  position: relative;
+  bottom: -3px;
+  display: inline-block;
+}
+
+span.opening-icon::after {
+    background-color: #a0a;
+}
+span.keynote-icon::after {
+    background-color: #e44;
+}
+span.demo-icon::after {
+    background-color: #66c;
+}
+span.cloud-icon::after {
+    background-color: #0a0;
+}
+span.panel-icon::after {
+    background-color: #c6a061;
 }
 
 // Fix issue with absolute position children not inheriting any height


### PR DESCRIPTION
Added new agenda to the plan of the day section. Added styling for
legend that displays the different session types with dots. These dots
have screen reader labels to be accessible.

Change-Id: I033af970cbd3cbcc856dbdd5433a6d11c7cd4700
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>