### PR TITLE
Update to Adam Bien session name

### DIFF
--- a/data/agenda.yml
+++ b/data/agenda.yml
@@ -25,7 +25,7 @@ items:
       presenter: Ivar Grimstad
       start: 9am EDT
       type: opening
-    - name: Live coding Jakarta EE + MicroProfile
+    - name: "Live Coding with Jakarta EE and MicroProfile #slideless"
       presenter: Adam Bien
       start: 10am EDT
       type: demo


### PR DESCRIPTION
Updated session name according to Tanja's request in #33

Change-Id: I52103c5f2210403268aefb89b1dc96cab2b196d4
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>