### PR TITLE
Add abtract page #75

### DIFF
--- a/data/en/japan2020/agenda.yml
+++ b/data/en/japan2020/agenda.yml
@@ -20,6 +20,10 @@ items:
       presenter: TBD
       type: opening
       time: 16:20-18:00
+      abstract: |
+        <p> 
+          This session's presenter has yet to be announced. Keep an eye on this space for more details in the near future.
+        </p>
     - name:  Break
       presenter: ―
       type: demo

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -22,6 +22,12 @@ other = "Scheduled Time"
 [agenda-session-recording-button-alt]
 other = "Session video for session {{ .name }}"
 
+[agenda-abstract-modal-alt]
+other = "View {{.name}} abstract"
+
+[agenda-modal-close-alt]
+other = "Close"
+
 [committee-carousel-title]
 other = "Meet the Program Committee"
 

--- a/i18n/jp.toml
+++ b/i18n/jp.toml
@@ -19,6 +19,12 @@ other = "ビデオ"
 [agenda-session-schedule]
 other = "時刻"
 
+[agenda-abstract-modal-alt]
+other = "View {{.name}} abstract"
+
+[agenda-modal-close-alt]
+other = "Close"
+
 [agenda-session-recording-button-alt]
 other = "セッション{{ .name }}のセッションビデオ"
 

--- a/js/custom.js
+++ b/js/custom.js
@@ -19,4 +19,16 @@ $(document).ready(function () {
         pagination: true,
         responsiveRefreshRate: 100
     });
+    
+});
+
+$('#eclipsefdn-modal').on('shown.bs.modal', function (event) {
+	  var $init = $(event.relatedTarget) // Button that triggered the modal
+	  var $modal = $(this);
+	  console.log('bing!')
+	  $modal.find('.modal-title').text($init.attr('data-title'));
+	  $modal.find('.modal-body').innerHTML($init.find('.modal-content').innerHTML());
+	  console.log($init.attr('data-title'))
+	  console.log($init.find('.modal-content'))
+	  
 });

--- a/js/home.modal.js
+++ b/js/home.modal.js
@@ -1,0 +1,8 @@
+$('#eclipsefdn-modal').on('show.bs.modal', function (event) {
+	  var $init = $(event.relatedTarget);
+	  var $modal = $(this);
+	  $modal.find('h4.modal-title').text($init.attr('data-title'));
+	  $modal.find('#modal-presenter').text($init.attr('data-presenter'));
+	  $modal.find('#modal-time').text($init.attr('data-time'));
+	  $modal.find('.modal-body').html($init.find('.modal-content')[0].innerHTML);
+});

--- a/layouts/partials/footer_custom.html
+++ b/layouts/partials/footer_custom.html
@@ -46,3 +46,22 @@
     </div>
   </div>
 </section>
+<!-- Modal for usage with agendas -->
+<div id="eclipsefdn-modal" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{ i18n "agenda-modal-close-alt" }}"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title"></h4>
+        <div class="margin-top-10">
+        	<p id="modal-presenter"></p>
+        	<p id="modal-time"></p>
+        </div>
+      </div>
+      <div class="modal-body">
+      </div>
+      <div class="modal-footer">
+      </div>
+    </div>
+  </div>
+</div>

--- a/layouts/partials/footer_suffix.html
+++ b/layouts/partials/footer_suffix.html
@@ -11,3 +11,4 @@
   SPDX-License-Identifier: EPL-2.0
 -->
 <script src="/js/home.slider.js"></script>
+<script src="/js/home.modal.js"></script>

--- a/layouts/shortcodes/agenda.html
+++ b/layouts/shortcodes/agenda.html
@@ -54,7 +54,23 @@
                   {{ .name }} 
                   {{ end}}
                    </span>
-                </span> {{ .name }}
+                </span> 
+	            {{ if isset . "link" }}
+	            <a href="{{ .link }}" title="{{ i18n "agenda-session-abstract-alt" . }}">
+	            {{ end }}
+	            {{ .name }}
+	            {{ if isset . "link" }}
+	            </a>
+	            {{ end }}
+	            {{ if isset . "abstract" }}
+	            <a class="margin-left-10" href="#" title="{{ i18n "agenda-abstract-modal-alt" . }}" data-toggle="modal" data-target="#eclipsefdn-modal" 
+	            	data-title="{{ .name }}" data-presenter="{{ .presenter }}" data-time="{{ .time }}">
+		            <i class="fa fa-external-link">
+		            	<span class="sr-only">{{ i18n "agenda-abstract-modal-alt" . }}</span>
+		            	<div class="modal-content hidden">{{ .abstract | safeHTML }}</div>
+		            </i>
+	            </a>
+	            {{ end }}
               </td>
               <td>{{ .presenter }}</td>
               

--- a/less/custom.less
+++ b/less/custom.less
@@ -122,6 +122,13 @@ section.alt {
         font-weight: 700;
         color: #fff;
     }
+    a {
+        color: #feb322;
+        font-weight: 700;
+    }
+    a:visited, a:hover, a:active {
+        color: #eda822;
+    }
 }
 section#about .backdrop {
     background-image: url('images/about-background.jpg');

--- a/static/mix-manifest.json
+++ b/static/mix-manifest.json
@@ -1,5 +1,6 @@
 {
     "/css/styles.css": "/css/styles.css",
     "/js/home.slider.js": "/js/home.slider.js",
+    "/js/home.modal.js": "/js/home.modal.js",
     "/js/solstice.js": "/js/solstice.js"
 }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -25,6 +25,7 @@ mix.styles([
 ],'static/css/styles.css');
 
 mix.copy('./js/home.slider.js', 'static/js/home.slider.js');
+mix.copy('./js/home.modal.js', 'static/js/home.modal.js');
 
 mix.scripts([
     './node_modules/jquery/dist/jquery.min.js',


### PR DESCRIPTION
Initial commit of work. 2 new i18n labels have been added that need
Japanese translation. Abstract support with modals or links has been
added. Sample modal content has been added to the 2020 event on the TBD
session with very generic content.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>