### PR TITLE
Fix session recording button #93

### DIFF
--- a/layouts/shortcodes/agenda.html
+++ b/layouts/shortcodes/agenda.html
@@ -76,7 +76,7 @@
               
               {{ if (index $langBase $event_id).agenda.complete }}
               <td class="text-center">
-              <a class="btn btn-primary btn-wide" href="{{ .vod }}" title="{{ i18n "agenda-session-recording-button-alt" . }}">
+              <a class="btn btn-primary" href="{{ .vod }}" title="{{ i18n "agenda-session-recording-button-alt" . }}">
                 <i class="fa fa-play fa-2x"></i> <span class="sr-only">{{ i18n "agenda-session-recording-button-alt" . }}</span>
               </a></td>
               {{ else }}

--- a/less/custom.less
+++ b/less/custom.less
@@ -122,7 +122,7 @@ section.alt {
         font-weight: 700;
         color: #fff;
     }
-    a {
+    a:not(.btn-primary) {
         color: #feb322;
         font-weight: 700;
     }
@@ -218,6 +218,8 @@ section#plan-of-the-day {
         font-size: 18px;
     }
     .btn-primary {
+    	color: @white;
+        width: 67%;
         border-radius: 10px;
     }
 }


### PR DESCRIPTION
Changed button to take up 67% width instead of full width of container,
and made the text white for agenda buttons to not impact other
behaviour.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>