### PR TITLE
Meta tag contains stale data #111

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 baseurl = "https://jakartaone.org/"
 #baseurl = "https://jakartaee.github.io/jakartaone.org/"
 DefaultContentLanguage = "en"
-title = "JakartaOne Live - September 10, 2019 | Jakarta EE Software | Cloud Native"
+title = "JakartaOne Live | Jakarta EE Software | Cloud Native"
 theme = "eclipsefdn-hugo-solstice-theme"
 metaDataFormat = "yaml"
 disableKinds = ["taxonomy", "taxonomyTerm"]
@@ -21,7 +21,7 @@ themesDir = "node_modules/"
 [Params]
   google_tag_manager = "GTM-5WLCZXC"
   description = "JakartaOne Live is a one day virtual conference for developers and technical business leaders that brings insights into the current state and future of Jakarta EE and related technologies focused on developing cloud-native Java applications."
-  subtitle = "JakartaOne Live - September 10, 2019 | Jakarta EE Software | Cloud Native"
+  subtitle = "JakartaOne Live | Jakarta EE Software | Cloud Native"
   seo_title_suffix = " | The Eclipse Foundation"
   keywords = ["JakartaOne", "JakartaOne Live", "Jakarta EE software", "Java EE", "cloud", "microservices", "enterprise", "open source", "innovation"]
   logo = "images/jakartaone_livestream_wht_full-06.svg"

--- a/content/_index.jp.md
+++ b/content/_index.jp.md
@@ -1,6 +1,6 @@
 ---
 title: "JakartaOne Live"
-seo_title: "JakartaOne Live - September 10, 2019 | Jakarta EE Software | Cloud Native"
+seo_title: "JakartaOne Live | Jakarta EE Software | Cloud Native"
 date: 2018-04-05T15:50:25-04:00
 hide_page_title: true
 hide_sidebar: true

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "JakartaOne Live"
-seo_title: "JakartaOne Live - September 10, 2019 | Jakarta EE Software | Cloud Native"
+seo_title: "JakartaOne Live | Jakarta EE Software | Cloud Native"
 date: 2018-04-05T15:50:25-04:00
 hide_page_title: true
 hide_sidebar: true

--- a/content/_index.pt.md
+++ b/content/_index.pt.md
@@ -1,6 +1,6 @@
 ---
 title: "JakartaOne Live"
-seo_title: "JakartaOne Live - September 10, 2019 | Jakarta EE Software | Cloud Native"
+seo_title: "JakartaOne Live | Jakarta EE Software | Cloud Native"
 date: 2018-04-05T15:50:25-04:00
 hide_page_title: true
 hide_sidebar: true


### PR DESCRIPTION
Updated tags to remove reference to date for event.

Fix #111

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>