### PR TITLE
JakartaOne Livestream-Date Change #171

### DIFF
--- a/content/2020/_index.md
+++ b/content/2020/_index.md
@@ -9,7 +9,7 @@ hide_breadcrumb: true
 show_featured_footer: false
 container: "container-fluid"
 headline: "JakartaOne Livestream"
-tagline: "September 16, 2020. 6:00 ET - 18:00 ET"
+tagline: "Fall 2020"
 tagline_suffix: "<p><img width='180' class='img-responsive center-block' src='/images/jakarta/jakarta-ee-logo.svg' alt='Jakarta EE: The New Home of Cloud Native Java'></p>"
 layout: "single"
 ---

--- a/data/en/conferences.yml
+++ b/data/en/conferences.yml
@@ -3,8 +3,8 @@ items:
   -
     name: JakartaOne 2020
     location: Location, Location
-    date: September 16, 2020
-    end_date: 2020-09-16T23:59:00-00:00
+    date: Fall 2020
+    end_date: 2020-11-16T23:59:00-00:00
     url: /2020
     logo_white: /images/jakartaone_livestream_wht_full-06.svg
     logo_color: /images/jakarta_one_logo.png

--- a/data/es/conferences.yml
+++ b/data/es/conferences.yml
@@ -3,11 +3,12 @@ items:
   -
     name: JakartaOne 2020
     location: Location, Location
-    date: September 16, 2020
-    end_date: 2020-09-16T23:59:00-00:00
+    date: Otoño 2020
+    end_date: 2020-11-16T23:59:00-00:00
     url: /2020
     logo_white: /images/jakartaone_livestream_wht_full-06.svg
     logo_color: /images/jakarta_one_logo.png
+    icon: fa fa-rocket
   -
     name: JakartaOne en Español 2020
     location: Virtual
@@ -16,7 +17,6 @@ items:
     url: /es/2020/hispano
     logo_white: /images/jakartaone_livestream_wht_full-06.svg
     logo_color: /images/jakarta_one_logo.png
-    icon: fa fa-rocket
   -
     name: Brazil 2020
     location: Virtual

--- a/data/jp/conferences.yml
+++ b/data/jp/conferences.yml
@@ -3,8 +3,8 @@ items:
   -
     name: JakartaOne 2020
     location: Location, Location
-    date: September 16, 2020
-    end_date: 2020-09-16T23:59:00-00:00
+    date: 2020年秋
+    end_date: 2020-11-16T23:59:00-00:00
     url: /2020
     logo_white: /images/jakartaone_livestream_wht_full-06.svg
     logo_color: /images/jakarta_one_logo.png

--- a/data/pt/conferences.yml
+++ b/data/pt/conferences.yml
@@ -3,8 +3,8 @@ items:
   -
     name: JakartaOne 2020
     location: Location, Location
-    date: September 16, 2020
-    end_date: 2020-09-16T23:59:00-00:00
+    date: Outono 2020
+    end_date: 2020-11-16T23:59:00-00:00
     url: /2020
     logo_white: /images/jakartaone_livestream_wht_full-06.svg
     logo_color: /images/jakarta_one_logo.png


### PR DESCRIPTION
Moved event to official event to Fall 2020, removed official event icon
from Spanish event in Spanish data file.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>