### PR TITLE
Capitalize P for Russian language switch

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,7 +21,7 @@ themesDir = "node_modules/"
     languageName = "Español"
     weight =  4
   [languages.ru]
-    languageName = "русский"
+    languageName = "Русский"
     weight =  5
 
 [Params]


### PR DESCRIPTION
According to https://github.com/jakartaee/jakartaone.org/issues/250  We need to Capitalize "P".

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>