### PR TITLE
Remove paragraph from past event tiles on homepage

### DIFF
--- a/layouts/shortcodes/home/past_events.html
+++ b/layouts/shortcodes/home/past_events.html
@@ -18,7 +18,6 @@
             </div>
             <div class="panel-body">
               <h3 class="fw-700">{{ .name }}</h3>
-              <p>{{ .description }}</p>
             </div>
           </div>
         </a>


### PR DESCRIPTION
Resolves #414 

Removes paragraph from past event tiles.