### PR TITLE
feat: update mary's title

### DIFF
--- a/data/en/2024/default/committee.yml
+++ b/data/en/2024/default/committee.yml
@@ -75,7 +75,7 @@ items:
         heavy metal concerts.
       </p>
   - name: "Mary Grygleski"
-    title: "Senior Developer Advocate, DataStax"
+    title: "AI Practice Lead, Callibrity"
     img: "mary-grygleski-2024.jpg"
     bio: |
       <p>


### PR DESCRIPTION
Resolves part of #545 

We are also waiting for a new bio to accompany the title change. But in the meantime, we'll go live without an updated bio.