### PR TITLE
feat: remove timezone from column heading of agenda

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -65,7 +65,7 @@ other = "Presenter Name"
 other = "Session Recording"
 
 [agenda-session-schedule]
-other = "Scheduled Time (Eastern Time)"
+other = "Scheduled Time"
 
 [agenda-session-recording-button-alt]
 other = "Session video for session {{ .name }}"


### PR DESCRIPTION
Otherwise this gets displayed on other event pages like JakartaOne China who in fact uses CST instead of EST.

Instead of displaying timezone in column heading, we are going to display it as a footnote to the table.